### PR TITLE
Fix for edits to sample describe fails

### DIFF
--- a/app/main/spec.html
+++ b/app/main/spec.html
@@ -15,7 +15,7 @@
             </md-button>
             <md-menu-content width="2">
               <md-menu-item>
-                <md-button ng-click="main.specDialog(main.spec)"><span md-menu-align-target>Edit Spec</span></md-button>
+                <md-button ng-click="main.specDialog($event)"><span md-menu-align-target>Edit Spec</span></md-button>
               </md-menu-item>
               <md-menu-item>
                 <md-button ng-click="main.duplicateSpec($index)"><span md-menu-align-target>Duplicate</span></md-button>


### PR DESCRIPTION
Fixes `this[0].focus is not a function` issue on edit mentioned on #30 